### PR TITLE
Amend unit testing for find Active Classes and Students

### DIFF
--- a/src/main/java/com/example/studentclass/Models/Class.java
+++ b/src/main/java/com/example/studentclass/Models/Class.java
@@ -14,7 +14,7 @@ import java.util.Set;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-
+@Builder
 public class Class extends EntityModel {
 
 

--- a/src/main/java/com/example/studentclass/Models/Student.java
+++ b/src/main/java/com/example/studentclass/Models/Student.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-
+@Builder
 public class Student extends EntityModel{
 
     @Id

--- a/src/test/java/com/example/studentclass/Services/ClassServiceTest.java
+++ b/src/test/java/com/example/studentclass/Services/ClassServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.studentclass.Services;
+
+import com.example.studentclass.Models.Class;
+import com.example.studentclass.Repositories.ClassRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.example.studentclass.Models.Status.ACTIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+
+@ExtendWith(MockitoExtension.class)
+class ClassServiceTest {
+
+    @Mock
+    private ClassRepo classRepo;
+
+    @InjectMocks
+    private ClassService classService;
+
+    private Class aClass;
+
+    @BeforeEach
+    public void setup(){
+        aClass = Class.builder()
+                .id(1L)
+                .name("Bestari")
+                .status(ACTIVE)
+                .build();
+    }
+
+    @DisplayName("JUnit test for find class by id")
+    @Test
+    public void givenClassObject_whenFindById_thenReturnClassObjectForThatId(){
+        //given-Pre Condition Setup;
+        given(classRepo.findById(aClass.getId())).willReturn(Optional.of(aClass));
+
+        //when-action or the behavior that we are going to test;
+        Class savedClass = classService.getClassById(aClass.getId());
+
+        //then-verify the output.
+        assertThat(savedClass).isNotNull();
+
+    }
+
+    @DisplayName("JUnit test for create/save Class")
+    @Test
+    public void givenClassObject_whenSaveClass_thenReturnClassObject(){
+        //given-Pre Condition Setup;
+        given(classRepo.save(aClass)).willReturn(aClass);
+
+        //when-action or the behavior that we are going to test;
+        Class savedClass = classService.createNewClass(aClass);
+
+        //then-verify the output.
+        assertThat(savedClass).isNotNull();
+    }
+
+    @DisplayName("JUnit test for get ACTIVE class")
+    @Test
+    public void givenClassObject_whenGetActiveClass_thenReturnClassObjectThatActive(){
+        //given-Pre Condition Setup;
+        Class class2 = Class.builder()
+                .name("Kasturi")
+                .status(ACTIVE)
+                .build();
+        given(classRepo.findAllActiveClasses()).willReturn(Arrays.asList(aClass, class2));
+
+        //when-action or the behavior that we are going to test;
+        classService.getAllActiveClasses();
+
+        //then-verify the output.
+        assertThat(aClass.getStatus()).isEqualTo(ACTIVE);
+        assertThat(class2.getStatus()).isEqualTo(ACTIVE);
+    }
+
+
+}

--- a/src/test/java/com/example/studentclass/Services/StudentServiceTest.java
+++ b/src/test/java/com/example/studentclass/Services/StudentServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.studentclass.Services;
+
+import com.example.studentclass.Models.Class;
+import com.example.studentclass.Models.Status;
+import com.example.studentclass.Models.Student;
+import com.example.studentclass.Repositories.ClassRepo;
+import com.example.studentclass.Repositories.StudentRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.example.studentclass.Models.Status.ACTIVE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StudentServiceTest {
+
+    @Mock
+    private StudentRepo studentRepo;
+
+    @Mock
+    private ClassRepo classRepo;
+
+    @InjectMocks
+    private StudentService studentService;
+
+    private Student student;
+    private Class aClass;
+
+    @BeforeEach
+    public void setUp(){
+        student = Student.builder()
+                .id(1L)
+                .name("Farhan")
+                .status(ACTIVE)
+                .address("Cheras")
+                .age(24)
+                .build();
+
+        aClass = Class.builder()
+                .id(1L)
+                .name("Bestari")
+                .status(ACTIVE)
+                .build();
+    }
+
+    @DisplayName("JUnit test for find student by id")
+    @Test
+    public void givenStudentObject_whenFindById_thenReturnStudentObjectForThatId(){
+        //given-Pre Condition Setup;
+        given(studentRepo.findById(student.getId())).willReturn(Optional.of(student));
+
+        //when-action or the behavior that we are going to test;
+        Student savedStudent = studentService.getStudentById(student.getId());
+
+        //then-verify the output.
+        assertThat(savedStudent).isNotNull();
+
+    }
+
+    @DisplayName("JUnit test for create/save Student and assign it to which class")
+    @Test
+    public void givenStudentObject_whenSaveStudentAndAssignItToClassId_thenReturnStudentObject(){
+        //given-Pre Condition Setup;
+        given(studentRepo.save(student)).willReturn(student);
+        given(classRepo.findById(aClass.getId())).willReturn(Optional.of(aClass));
+
+        //when-action or the behavior that we are going to test;
+        Student newStudent = studentService.createNewStudent(student, aClass.getId());
+
+        //then-verify the output.
+        assertThat(newStudent).isNotNull();
+    }
+
+    @DisplayName("JUnit test for get ACTIVE students")
+    @Test
+    public void givenStudentObject_whenGetActiveStudents_thenReturnStudentObjectThatActive(){
+        //given-Pre Condition Setup;
+        Student student1 = Student.builder()
+                .id(1L)
+                .name("Akmal")
+                .status(ACTIVE)
+                .address("Bangsar")
+                .age(23)
+                .build();
+
+        given(studentRepo.findAllActiveStudents()).willReturn(Arrays.asList(student, student1));
+
+        //when-action or the behavior that we are going to test;
+        studentService.getActiveStudents();
+
+        //then-verify the output.
+        assertThat(student.getStatus()).isEqualTo(ACTIVE);
+        assertThat(student1.getStatus()).isEqualTo(ACTIVE);
+    }
+
+}


### PR DESCRIPTION
**Description:**

I've added a unit testing of service layer for both domain objects, Student and Class.

I'm using Mockito to Mock the Repository layer and Inject it to the Service Layer.

As we're using Java 8, I had to use Arrays.asList to replace List.Of which is not available in Java 8 to return the List of the Objects .

Please take a look.